### PR TITLE
Rename 2 functions (change 'send' by 'get')

### DIFF
--- a/code/API.py
+++ b/code/API.py
@@ -208,11 +208,11 @@ class API:
             return APILogic.predict(request)
 
         @self.app.route('/get_predictions', methods=['GET'])
-        def send_predictions():
+        def get_predictions():
             """
-            Send predictions route.
+            Return predictions.
 
-            This endpoint sends the predictions to the client.
+            This endpoint return the predictions to the client.
 
             ---
             parameters:
@@ -228,14 +228,14 @@ class API:
                     description: An error occurred
             :return:
             """
-            return APILogic.send_predictions()
+            return APILogic.get_predictions()
 
         @self.app.route('/get_columns', methods=['GET'])
-        def send_columns():
+        def get_columns():
             """
-            Send columns route.
+            Return column names.
 
-            This endpoint sends the columns of the dataset to the client.
+            This endpoint return thee column names of the dataset to the client.
 
             ---
             responses:
@@ -245,7 +245,7 @@ class API:
                     description: An error occurred
             :return:
             """
-            return APILogic.send_columns()
+            return APILogic.get_columns()
 
     def _get_routes(self) -> jsonify:
         """

--- a/code/api_logic.py
+++ b/code/api_logic.py
@@ -75,20 +75,21 @@ class APILogic:
             return jsonify({'error': 'Only CSV files are allowed'}), 400
 
     @classmethod
-    def send_predictions(cls):
+    def get_predictions(cls):
         """
-        Sends the predictions as a CSV file.
+        Return the predictions as a CSV file.
         :return:
         """
         predictions = "../dataset_examples/drinks.csv"
         return send_file(predictions, as_attachment=True, download_name='predictions.csv')
 
     @classmethod
-    def send_columns(cls):
+    def get_columns(cls):
         """
-        Sends the columns of the dataset.
+        Return the columns of the dataset.
         :return:
         """
+        print(AILogic.df.columns)
         columns = AILogic.df.columns.values.tolist()
         response = jsonify({'columns': columns})
         response.headers.add('Access-Control-Allow-Origin', '*')


### PR DESCRIPTION
### Rename 2 functions (change 'send' by 'get')

#### Explanation
It was making more sense that the functions would be called "get" instead of "send", as the method used is GET and not POST.